### PR TITLE
Fix error preventing use of custom converter

### DIFF
--- a/brte/engine.py
+++ b/brte/engine.py
@@ -66,7 +66,7 @@ class RealTimeEngine():
         self.override_context = None
 
         if 'converter' in kwargs:
-            self.converter = converter
+            self.converter = kwargs['converter']
         else:
             self.converter = _converters.BTFConverter()
 


### PR DESCRIPTION
Passing in a custom converter to the BRTE makes it give an error.  This patch fixes that.